### PR TITLE
Update TypeScript `README`

### DIFF
--- a/docs/3_development/2_tech-stack/Typescript/readme.md
+++ b/docs/3_development/2_tech-stack/Typescript/readme.md
@@ -154,7 +154,7 @@ jobs:
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v4
+      - uses: amannn/action-semantic-pull-request@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -198,7 +198,7 @@ jobs:
         with:
           release-type: node
           package-name: release-please-action
-          changelog-types: '[{"type":"feat","section":"Features","hidden":false},{"type":"fix","section":"Bug Fixes","hidden":false},{"type":"chore","section":"Miscellaneous","hidden":true}]'
+          changelog-types: '[{"type":"feat","section":"Features","hidden":false},{"type":"fix","section":"Bug Fixes","hidden":true},{"type":"chore","section":"Miscellaneous","hidden":true}]'
       
       - uses: actions/checkout@v3
         # these if statements ensure that a publication only occurs when

--- a/docs/3_development/2_tech-stack/Typescript/readme.md
+++ b/docs/3_development/2_tech-stack/Typescript/readme.md
@@ -198,7 +198,7 @@ jobs:
         with:
           release-type: node
           package-name: release-please-action
-          changelog-types: '[{"type":"feat","section":"Features","hidden":false},{"type":"fix","section":"Bug Fixes","hidden":true},{"type":"chore","section":"Miscellaneous","hidden":true}]'
+          changelog-types: '[{"type":"feat","section":"Features","hidden":false},{"type":"fix","section":"Bug Fixes","hidden":false},{"type":"chore","section":"Miscellaneous","hidden":true}]'
       
       - uses: actions/checkout@v3
         # these if statements ensure that a publication only occurs when


### PR DESCRIPTION
https://github.com/ChainSafe/dappeteer/actions/runs/4065765837/jobs/7000927535

tldr
> `set-output` command is deprecated and will be disabled soon
and that is solved in `amannn/action-semantic-pull-request` v5

# Description
<!--Please briefly describe ALL changes included in the PR-->

# Issues
<!--Please list all issues this PR closes (they will be closed automatically)-->

**Closes**: #?
