### PR TITLE
Run deploy only after successull check

### DIFF
--- a/.github/workflows/cf-deploy.yaml
+++ b/.github/workflows/cf-deploy.yaml
@@ -1,9 +1,15 @@
 name: CloudFlare Deploy
-on: [push]
+on:
+  workflow_run:
+    workflows:
+      - CI
+    types:
+      - completed
 
 jobs:
   deploy:
       runs-on: ubuntu-latest
+      if: ${{ github.event.workflow_run.conclusion == 'success' }}
       permissions:
         contents: read
         deployments: write

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -2,7 +2,7 @@ name: CI
 on: 
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
       - '**'


### PR DESCRIPTION
# Description
This PR updates GH Actions workflow so it runs CfloudFlare Page deploy only after CI check compelted successfully. 