### PR TITLE
fix: dead link on careers

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -21,7 +21,7 @@ const sidebars = {
       },
     {
       type: 'link',
-      href: "https://chainsafe.io/careers",
+      href: "https://chainsafe.io/about-us#join-us",
       label: "Join ChainSafe",
       className: "join-us"
     }


### PR DESCRIPTION
# Description
<!--Please briefly describe ALL changes included in the PR-->

The https://chainsafe.io/careers is a dead link due to CS page revamp. Changed it to a working link.

# Issues
<!--Please list all issues this PR closes (they will be closed automatically)-->

**Closes**: #?
