### PR TITLE
docs(skills): propagate I/O timeout, API isolation, and feature-gating rules

### DIFF
--- a/skills/chainsafe-go-architect/SKILL.md
+++ b/skills/chainsafe-go-architect/SKILL.md
@@ -32,6 +32,8 @@ When designing a Go system or module, address:
   - No package-level mutable state.
 - **Error model.** Errors are values. Sentinel errors with `errors.Is`, typed errors with `errors.As`. `fmt.Errorf("...: %w", err)` to preserve context. Never `panic` for non-fatal errors.
 - **Dependency injection.** Functional options or explicit `Settings` structs. No globals, no hidden singletons.
+- **Defensive network & disk I/O.** Every external network call, database query, or stream reader must have an explicit timeout — `context.WithTimeout` on the call, or socket/read deadlines where context isn't threaded through. A `ctx` without a deadline is not a timeout; an unbounded read is a hang waiting to happen.
+- **API & storage isolation.** Keep internal domain models separate from external transport layers. Define Data Transfer Objects (DTOs) for external APIs and database schemas, and map them explicitly to internal models at the boundary. This is for *external* edges — don't introduce DTOs between internal packages.
 
 ## ADR template for Go work
 

--- a/skills/chainsafe-go-developer/SKILL.md
+++ b/skills/chainsafe-go-developer/SKILL.md
@@ -54,6 +54,8 @@ func DoThing(ctx context.Context, arg T) (Result, error) {
 
 `ctx` is the first parameter. Always. Never `context.TODO()` in committed code. Pass `ctx` down; do not store in structs except in narrow framework cases.
 
+Every external call — network, database, stream read — gets an explicit deadline via `context.WithTimeout` (or a socket/read deadline where `ctx` isn't threaded through). An inherited `ctx` with no deadline is not a timeout.
+
 ## Errors
 
 ```go

--- a/skills/chainsafe-go-reviewer/SKILL.md
+++ b/skills/chainsafe-go-reviewer/SKILL.md
@@ -23,6 +23,7 @@ Reviewer skill for Go PRs. Operates under [`workflows/code-review.md`](../../wor
 ### Concurrency
 
 - `context.Context` propagation — every I/O or potentially-blocking function takes `ctx` as first parameter and uses it.
+- Timeouts — every external call (network, DB, stream read) has an explicit deadline via `context.WithTimeout` or a socket/read deadline. An inherited `ctx` with no deadline is not a timeout; flag it.
 - Goroutine ownership — every `go func()` has a clear exit (ctx.Done, wg.Done, bounded scope).
 - Unbounded concurrency — `for ... { go work() }` without limits is a bug for large inputs.
 - Data races — shared mutable state across goroutines needs a mutex or channel; `go test -race` runs.
@@ -46,6 +47,7 @@ Reviewer skill for Go PRs. Operates under [`workflows/code-review.md`](../../wor
 - New packages default to `internal/`. Move to `pkg/` only with explicit justification.
 - Package names: single word, descriptive, no `utils`/`helpers`/`common`.
 - `main.go` is minimal; logic lives elsewhere.
+- Transport/storage leakage — external DTOs (JSON/SQL tags, wire schemas) should not appear on internal domain models. Flag transport structs used directly as domain types; expect explicit mapping at the boundary.
 
 ### Testing
 

--- a/skills/chainsafe-rust-architect/SKILL.md
+++ b/skills/chainsafe-rust-architect/SKILL.md
@@ -37,6 +37,7 @@ ChainSafe Rust projects use Cargo workspaces (Forest is the canonical example):
 - **`#[tokio::main]` only in the binary crate.** Library crates stay runtime-agnostic where possible.
 - **Bounded concurrency:** `FuturesUnordered` with limits, `tokio::sync::Semaphore`, `buffer_unordered` on streams. Unbounded futures-spawn is a leak.
 - **`Send + Sync + 'static` bounds** — design types so they meet what `tokio::spawn` requires.
+- **Bounded Duration:** Every potentially blocking external `.await` boundary (network I/O, database interaction, channel reads across subsystems) must have a strict timeout boundary. Combine bounded concurrency (caps *how many*) with bounded duration (caps *how long*) to prevent task pool exhaustion.
 
 ### Concurrency primitives
 
@@ -50,6 +51,14 @@ ChainSafe Rust projects use Cargo workspaces (Forest is the canonical example):
 - **`#[non_exhaustive]`** on enums and structs that may grow.
 - **Builder pattern** for complex constructors.
 - **No leaking tokio types in library APIs** unless feature-gated.
+- **API & storage isolation.** Keep internal domain types separate from external transport layers. Define serde/wire and database DTOs at the boundary and map them explicitly to domain models; don't hang `#[derive(Serialize, Deserialize)]` or storage-schema concerns directly on domain types. External edges only — not between internal modules.
+
+### Feature-gating and compilation boundaries
+
+- **Lean defaults.** Keep `default = []` as minimal as possible. Heavy dependencies (tracing subscribers, database drivers, serialization codecs, dev utilities) live behind optional cargo features, not in the default build.
+- **Environment isolation.** Abstract environment-specific logic — mocks, test vectors, alternative networking layers — behind descriptive gates like `test-utils` or `mock`. Never leak testing dependencies into production builds.
+- **Conditional compilation.** Apply `#[cfg(feature = "...")]` intentionally on modules and public entry points so that turning a feature off fully removes its artifacts and upstream dependencies from the compilation graph.
+- **Features are additive.** Cargo unifies feature sets across the workspace, so a feature may only *add* behavior — never remove or swap it. A `mock` gate that replaces real behavior breaks the moment two crates in one build enable different sets; design gates to layer, not to toggle.
 
 ### Unsafe
 

--- a/skills/chainsafe-rust-developer/SKILL.md
+++ b/skills/chainsafe-rust-developer/SKILL.md
@@ -44,6 +44,7 @@ components = ["rustfmt", "clippy"]
 - `cargo audit` in CI.
 - `cargo deny` for license/source/version policy.
 - Workspace-level dependency declarations to keep versions consistent.
+- **Feature-gating.** Keep `default = []` lean — heavy deps (tracing subscribers, DB drivers, codecs, dev utilities) go behind optional features. Put mocks/test vectors behind `test-utils` or `mock` gates; never leak test deps into production builds. Features must be *additive* (Cargo unifies them across the workspace) — a gate may add behavior, never swap it.
 
 ## Error handling
 
@@ -82,6 +83,7 @@ pub fn fetch(key: &str) -> Result<Data> {
 - `.await` propagates cancellation — hold no critical invariant across an `.await`.
 - `spawn` for async; `spawn_blocking` for CPU-bound. Mixing them up starves the runtime.
 - `Send + Sync + 'static` bounds on spawned tasks.
+- Every external `.await` (network, DB, cross-subsystem channel read) gets an explicit deadline via `tokio::time::timeout`. Bounded concurrency caps *how many*; this caps *how long* — an `.await` with no timeout hangs forever.
 
 ## Unsafe
 
@@ -108,6 +110,7 @@ Forest's [`AI_POLICY.md`](https://github.com/ChainSafe/forest/blob/main/AI_POLIC
 - **Newtypes for domain types.** `pub struct UserId(u64)`.
 - **`From` / `TryFrom`** for conversions over inherent `to_*` methods.
 - **`Deref` only for smart pointers** — don't fake inheritance.
+- **API & storage isolation.** Keep `#[derive(Serialize, Deserialize)]` and storage-schema concerns off domain types. Define serde/wire and DB DTOs at the boundary and map them explicitly to domain models. External edges only — not between internal modules.
 
 ## Anti-patterns
 

--- a/skills/chainsafe-rust-reviewer/SKILL.md
+++ b/skills/chainsafe-rust-reviewer/SKILL.md
@@ -42,6 +42,7 @@ Reviewer skill for Rust PRs. Universal review framework at [`workflows/code-revi
 - `.await` doesn't span a critical invariant.
 - `spawn` vs `spawn_blocking` — CPU-bound work in `spawn` starves the runtime.
 - No unbounded `FuturesUnordered` / `JoinSet`.
+- External `.await` (network, DB, cross-subsystem channel read) has an explicit deadline via `tokio::time::timeout`. Bounded concurrency is not bounded duration — flag a timeout-less external await.
 
 ### API design
 
@@ -49,6 +50,7 @@ Reviewer skill for Rust PRs. Universal review framework at [`workflows/code-revi
 - `#[non_exhaustive]` on enums and structs that may grow.
 - No tokio types in public library APIs unless feature-gated.
 - Newtypes for domain values.
+- Transport/storage leakage — `#[derive(Serialize, Deserialize)]` or DB-schema attributes on domain types. Expect serde/DB DTOs at the boundary mapped explicitly to domain models; flag wire/storage concerns hung directly on domain types.
 
 ### Concurrency primitives
 
@@ -75,6 +77,7 @@ Reviewer skill for Rust PRs. Universal review framework at [`workflows/code-revi
 - No unjustified new crates.
 - License compatibility (GPL into Apache 2.0 is blocking).
 - `cargo audit` clean.
+- Lean `default = []` — heavy deps (tracing subscribers, DB drivers, codecs, dev utilities) behind optional features; test deps (`test-utils`/`mock`) not leaking into production builds. Flag features that swap rather than add behavior (Cargo unifies them workspace-wide).
 
 ## Refusal
 


### PR DESCRIPTION
## Summary

Add three cross-cutting rules through the Go and Rust role-skill trios, keeping architect (decide) → developer (write) → reviewer (catch) in sync:

- Defensive I/O: every external network/DB/stream call needs an explicit deadline (context.WithTimeout / tokio::time::timeout); an inherited ctx with no deadline is not a timeout.
- API & storage isolation: keep transport/storage DTOs (JSON/SQL tags, serde derives, DB schemas) off internal domain types; map at the boundary.
- Feature-gating (Rust only): lean default = [], test deps behind test-utils/mock gates, additive-only features.